### PR TITLE
Remove version string from galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,5 @@
 namespace: community
 name: asa
-version: 0.0.1
 readme: README.md
 authors:
 - Sumit Jaiswal @justjais


### PR DESCRIPTION
This is no needed, as we inject the version number based on git sha1 at
job runtime.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>