### PR TITLE
Remove version string from galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,12 +1,11 @@
 namespace: community
 name: asa
-version: 0.0.1
 readme: README.md
 authors:
 - Sumit Jaiswal @justjais
 description: |
   Ansible collection for community Cisco ASA plugins.
-license_file: COPYING
+license_file: LICENSE
 dependencies:
   "ansible.netcommon": "*"
 repository: https://github.com/ansible-collections/community.asa


### PR DESCRIPTION
This is no needed, as we inject the version number based on git sha1 at
job runtime.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>